### PR TITLE
supertuxkart: initial recipe for v0.8.1

### DIFF
--- a/recipes-games/supertuxkart/files/0001-Use-system-s-glext.h-glxext.h-on-linux.patch
+++ b/recipes-games/supertuxkart/files/0001-Use-system-s-glext.h-glxext.h-on-linux.patch
@@ -1,0 +1,28 @@
+From 8771edf61fcf3ced4afb9e9bc08897f575d86834 Mon Sep 17 00:00:00 2001
+From: Deve <deveee@gmail.com>
+Date: Sat, 17 May 2014 09:18:25 +0200
+Subject: [PATCH 1/2] Use system's glext.h/glxext.h on linux.
+
+---
+ lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h b/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
+index 7f9e0df..586d0c4 100644
+--- a/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
++++ b/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
+@@ -61,9 +61,9 @@
+ 	#include <GL/gl.h>
+ 	#include <GL/glx.h>
+ 	#if defined(_IRR_OPENGL_USE_EXTPOINTER_)
+-	#include "glext.h"
++	#include <GL/glext.h>
+ 	#undef GLX_ARB_get_proc_address // avoid problems with local glxext.h
+-	#include "glxext.h"
++	#include <GL/glxext.h>
+ 	#endif
+ #endif
+ 
+-- 
+2.1.4
+

--- a/recipes-games/supertuxkart/files/0002-Applied-patch-from-jpirie-for-fixing-mesa-10-compila.patch
+++ b/recipes-games/supertuxkart/files/0002-Applied-patch-from-jpirie-for-fixing-mesa-10-compila.patch
@@ -1,0 +1,33 @@
+From 1a922afa0b03b9cc35e9fb4945deb3f73a5d39b4 Mon Sep 17 00:00:00 2001
+From: Deve <deveee@gmail.com>
+Date: Sat, 17 May 2014 09:21:07 +0200
+Subject: [PATCH 2/2] Applied patch from jpirie for fixing mesa 10 compilation
+ problems.
+
+---
+ lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h b/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
+index 586d0c4..b39f8b5 100644
+--- a/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
++++ b/lib/irrlicht/source/Irrlicht/COpenGLExtensionHandler.h
+@@ -49,6 +49,7 @@
+ 	#define NO_SDL_GLEXT
+ 	#include <SDL/SDL_video.h>
+ 	#include <SDL/SDL_opengl.h>
++	typedef void (APIENTRYP PFNGLBLENDEQUATIONPROC) (GLenum mode);
+ 	#include "glext.h"
+ #else
+ 	#if defined(_IRR_OPENGL_USE_EXTPOINTER_)
+@@ -61,6 +62,7 @@
+ 	#include <GL/gl.h>
+ 	#include <GL/glx.h>
+ 	#if defined(_IRR_OPENGL_USE_EXTPOINTER_)
++	typedef void (APIENTRYP PFNGLBLENDEQUATIONPROC) (GLenum mode);
+ 	#include <GL/glext.h>
+ 	#undef GLX_ARB_get_proc_address // avoid problems with local glxext.h
+ 	#include <GL/glxext.h>
+-- 
+2.1.4
+

--- a/recipes-games/supertuxkart/supertuxkart_0.8.1.bb
+++ b/recipes-games/supertuxkart/supertuxkart_0.8.1.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "SuperTuxKart is a kart racing game featuring Tux and his friends"
+HOMEAPAGE = "http://supertuxkart.sourceforge.net"
+SECTION = "x11/application"
+LICENSE = "GPLv2 & GPLv3+ "
+LIC_FILES_CHKSUM = "file://COPYING;md5=a71cb78659d60f2ced58a594cb65bfba"
+
+DEPENDS = "libogg libvorbis libxrandr virtual/libgl openal-soft fribidi curl"
+
+inherit cmake
+
+S = "${WORKDIR}/SuperTuxKart-${PV}"
+
+SRC_URI = "http://sourceforge.net/projects/supertuxkart/files/SuperTuxKart/${PV}/supertuxkart-${PV}-src.tar.bz2;protocol=https \
+           file://0001-Use-system-s-glext.h-glxext.h-on-linux.patch  \
+           file://0002-Applied-patch-from-jpirie-for-fixing-mesa-10-compila.patch"
+
+SRC_URI[md5sum] = "aa31ecf883dc35859eec76c667f1a6d6"
+SRC_URI[sha256sum] = "335301ae61b0c177be68d5593c65e5b197dc807421f08a8a35740a254cacf8d6"
+


### PR DESCRIPTION
* the 2 patches are needed to build against mesa 10, they are backported from
  upstream, since there is no new release as of yet.
* tested on Snapdragon (ARMv7 + adreno GPU), running freedreno Mesa Gallium
  driver
* Build tested for qemux86

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>