### PR TITLE
pingus: fix build in latest environment

### DIFF
--- a/recipes-games/pingus/pingus_0.7.6.bb
+++ b/recipes-games/pingus/pingus_0.7.6.bb
@@ -16,7 +16,7 @@ SRC_URI = "\
   file://pingus.png \
 "
 
-EXTRA_OESCONS = "CC='${CC}' CXX='${CXX}'"
+EXTRA_OESCONS = "CC='${CC} -fPIC' CXX='${CXX} -fPIC'"
 
 do_install() {
 	install -d ${D}${bindir}


### PR DESCRIPTION
fix:

| ld: error: build/libpingus.a(screenshot.o): requires unsupported dynamic reloc R_ARM_THM_MOVW_ABS_NC; recompile with -fPIC

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>