### PR TITLE
libsdl-net: fix build by using pkg-config to find SDL

### DIFF
--- a/dependencies/libsdl-net/libsdl-net_1.2.8.bb
+++ b/dependencies/libsdl-net/libsdl-net_1.2.8.bb
@@ -12,9 +12,7 @@ SRC_URI = " \
 
 S = "${WORKDIR}/SDL_net-${PV}"
 
-inherit autotools
-
-EXTRA_OECONF += "SDL_CONFIG=${STAGING_BINDIR_CROSS}/sdl-config"
+inherit autotools pkgconfig
 
 SRC_URI[md5sum] = "20e64e61d65662db66c379034f11f718"
 SRC_URI[sha256sum] = "5f4a7a8bb884f793c278ac3f3713be41980c5eedccecff0260411347714facb4"


### PR DESCRIPTION
Interesting: libsdl-net is prepared well for using pkg-config to find SDL.
Fixes:

| arm-angstrom-linux-gnueabi-gcc: error: unrecognized command line option '--should-not-have-used-/usr/bin/sdl-config'

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>