### PR TITLE
Images bistic-devel & usbistic: fix parse

### DIFF
--- a/recipes-images/bistic-devel/bistic-devel.bb
+++ b/recipes-images/bistic-devel/bistic-devel.bb
@@ -5,13 +5,13 @@ IMAGE_LINGUAS = " "
 
 LICENSE = "GPLv2"
 
-inherit core-image image-vm
+inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 
 IMAGE_FEATURES += "package-management x11-base x11-sato ssh-server-dropbear"
 
-IMAGE_FSTYPES += "vmdk"
+IMAGE_FSTYPES += "wic.vmdk"
 
 FREECIV = "\
  freeciv-server \

--- a/recipes-images/usbistic/usbistic.bb
+++ b/recipes-images/usbistic/usbistic.bb
@@ -5,13 +5,13 @@ IMAGE_LINGUAS = " "
 
 LICENSE = "GPLv2"
 
-inherit core-image image-vm
+inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 
 IMAGE_FEATURES += "package-management x11-base x11-sato ssh-server-dropbear"
 
-IMAGE_FSTYPES += "vmdk"
+IMAGE_FSTYPES += "wic.vmdk"
 
 FREECIV = "\
  freeciv-server \


### PR DESCRIPTION
OE-Core's commit 929ba563f1bc7195c4981b8e139c432b2cc388ea removed
image-vm.bbclass. Images were not tested but if the commit message was read
properly, the image creation job should be done by replacing image-type vdmk
by wic.vmdk.

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>