### PR TITLE
pingus: remove unused translation scripts

### DIFF
--- a/recipes-games/pingus/pingus_0.7.6.bb
+++ b/recipes-games/pingus/pingus_0.7.6.bb
@@ -27,6 +27,9 @@ do_install() {
 	install -d ${D}${datadir}/applications
 	install -m 0644 ${WORKDIR}/pingus.png ${D}${datadir}/pixmaps
 	cp -dR ${S}/data ${D}/${datadir}/pingus
+	rm ${D}/${datadir}/pingus/data/po/*.sh
+	rm ${D}/${datadir}/pingus/data/po/*.guile
+	rm ${D}/${datadir}/pingus/data/po/*.pot
 	install -m 0644 ${WORKDIR}/pingus.desktop ${D}${datadir}/applications
 	install -m 0755 ${S}/build/pingus ${D}${bindir}/pingus
 }


### PR DESCRIPTION
With current oe-core they cause QA errors

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>