### PR TITLE
scummvm: fix parse with recent oe-core

### DIFF
--- a/recipes-games/scummvm/scummvm_1.5.0.bb
+++ b/recipes-games/scummvm/scummvm_1.5.0.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
 "
 
 DEPENDS = "virtual/libsdl libvorbis libogg zlib flac faad2 \
-           ${@base_conditional('ENTERPRISE_DISTRO', '1', '', 'libmad mpeg2dec', d)}"
+           ${@oe.utils.conditional('ENTERPRISE_DISTRO', '1', '', 'libmad mpeg2dec', d)}"
 
 EXTRA_OECONF = " \
   --host=${HOST_SYS} \
@@ -29,7 +29,7 @@ EXTRA_OECONF = " \
   --default-dynamic \
   --enable-all-engines \
   --disable-fluidsynth \
-  ${@base_conditional('ENTERPRISE_DISTRO', '1', '--disable-mad', '--with-mad-prefix=${STAGING_LIBDIR}/..', d)} \
+  ${@oe.utils.conditional('ENTERPRISE_DISTRO', '1', '--disable-mad', '--with-mad-prefix=${STAGING_LIBDIR}/..', d)} \
 "
 
 EXTRA_OEMAKE = "MANDIR=${mandir}"


### PR DESCRIPTION
Thanks to oe-core:

commit 0391fcad9103abca0796a068f957d0df63ab4776
Author: Ross Burton <ross.burton@intel.com>
Date:   Mon Jan 29 17:11:10 2018 +0000

    classes/utils: remove compatibility functions

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>