### PR TITLE
layer.conf: Add LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,3 +7,5 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/dependencies/*/*.bb ${LAYERD
 BBFILE_COLLECTIONS += "games-layer"
 BBFILE_PATTERN_games-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_games-layer = "15"
+
+LAYERSERIES_COMPAT_games-layer = "rocko sumo"


### PR DESCRIPTION
Remove warnings caused by oe-core changes [1].

Recipes building should be compatible to rocko and sumo

[1] http://lists.openembedded.org/pipermail/openembedded-architecture/2018-April/000722.html

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>