### PR TITLE
wesnoth: upgrade 1.14.4 -> 1.14.4

### DIFF
--- a/recipes-games/pingus/pingus/0002-Fix-build-with-boost-1.69.0.patch
+++ b/recipes-games/pingus/pingus/0002-Fix-build-with-boost-1.69.0.patch
@@ -1,0 +1,384 @@
+From 56657b7e9aee01340487ce7f70083ca89da0aa1b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20M=C3=BCller?= <schnitzeltony@gmail.com>
+Date: Fri, 15 Mar 2019 21:50:35 +0100
+Subject: [PATCH] Fix build with boost >= 1.69.0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+See further details at [1] / stolen from [2]
+
+[1] https://www.boost.org/doc/libs/1_69_0/doc/html/signals2/api_changes.html
+[2] https://src.fedoraproject.org/cgit/rpms/pingus.git/plain/pingus-0.7.6-boost-169.patch
+
+Upstream-Status: Pending
+
+Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+---
+
+diff --git a/SConscript b/SConscript
+index 54b6468..b41df6e 100644
+--- a/SConscript
++++ b/SConscript
+@@ -77,7 +77,7 @@ class Project:
+         self.configure_linuxevdev()
+         self.configure_wiimote()
+         self.configure_xinput()
+-        self.configure_boost()
++    #   self.configure_boost()
+         self.configure_png()
+         self.configure_sdl()
+         self.configure_iconv()
+@@ -187,8 +187,8 @@ class Project:
+                                                      'src/engine/input/xinput/xinput_device.cpp'])
+             
+     def configure_boost(self):
+-        if not self.conf.CheckLibWithHeader('boost_signals', 'boost/signals.hpp', 'c++'):
+-            if not self.conf.CheckLibWithHeader('boost_signals-mt', 'boost/signals.hpp', 'c++'):
++        if not self.conf.CheckLibWithHeader('boost_signals', 'boost/signals2.hpp', 'c++'):
++            if not self.conf.CheckLibWithHeader('boost_signals-mt', 'boost/signals2.hpp', 'c++'):
+                 self.fatal_error += "  * library 'boost_signals' not found\n"
+ 
+     def configure_png(self):
+diff --git a/src/editor/button.hpp b/src/editor/button.hpp
+index c85d7da..d89dfe6 100644
+--- a/src/editor/button.hpp
++++ b/src/editor/button.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_BUTTON_HPP
+ #define HEADER_PINGUS_EDITOR_BUTTON_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/gui/rect_component.hpp"
+ 
+@@ -48,7 +48,7 @@ public:
+   void enable()  { enabled = true; }
+   void disable() { enabled = false; }
+ 
+-  boost::signal<void()> on_click;
++  boost::signals2::signal<void()> on_click;
+ 
+ private:
+   Button (const Button&);
+diff --git a/src/editor/checkbox.hpp b/src/editor/checkbox.hpp
+index 7c3bc83..66382d7 100644
+--- a/src/editor/checkbox.hpp
++++ b/src/editor/checkbox.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_CHECKBOX_HPP
+ #define HEADER_PINGUS_EDITOR_CHECKBOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/gui/rect_component.hpp"
+ 
+@@ -40,7 +40,7 @@ public:
+   bool is_checked() const { return checked; }
+   void on_primary_button_press(int x, int y);
+ 
+-  boost::signal<void (bool)> on_change;
++  boost::signals2::signal<void (bool)> on_change;
+  
+ private:
+   Checkbox (const Checkbox&);
+diff --git a/src/editor/combobox.hpp b/src/editor/combobox.hpp
+index 0ca7425..603556b 100644
+--- a/src/editor/combobox.hpp
++++ b/src/editor/combobox.hpp
+@@ -18,7 +18,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_COMBOBOX_HPP
+ #define HEADER_PINGUS_EDITOR_COMBOBOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/display/sprite.hpp"
+ #include "engine/gui/rect_component.hpp"
+@@ -88,7 +88,7 @@ public:
+   
+   void update_layout() {}
+   
+-  boost::signal<void (const ComboItem&)> on_select;
++  boost::signals2::signal<void (const ComboItem&)> on_select;
+ 
+ private:
+   Combobox();
+diff --git a/src/editor/file_list.hpp b/src/editor/file_list.hpp
+index cc4bba2..85efe6a 100644
+--- a/src/editor/file_list.hpp
++++ b/src/editor/file_list.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_FILE_LIST_HPP
+ #define HEADER_PINGUS_EDITOR_FILE_LIST_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/display/sprite.hpp"
+ #include "engine/gui/rect_component.hpp"
+@@ -61,7 +61,7 @@ public:
+   bool has_more_next_pages();
+   bool has_more_prev_pages();
+ 
+-  boost::signal<void (const System::DirectoryEntry&)> on_click;
++  boost::signals2::signal<void (const System::DirectoryEntry&)> on_click;
+ 
+ private:
+   int items_per_page();
+diff --git a/src/editor/inputbox.hpp b/src/editor/inputbox.hpp
+index cad9663..87321db 100644
+--- a/src/editor/inputbox.hpp
++++ b/src/editor/inputbox.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_INPUTBOX_HPP
+ #define HEADER_PINGUS_EDITOR_INPUTBOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/gui/rect_component.hpp"
+ 
+@@ -40,8 +40,8 @@ public:
+ 
+   void update_layout() {}
+ 
+-  boost::signal<void (const std::string&)> on_change;
+-  boost::signal<void (const std::string&)> on_enter;
++  boost::signals2::signal<void (const std::string&)> on_change;
++  boost::signals2::signal<void (const std::string&)> on_enter;
+ 
+ private:
+   Inputbox (const Inputbox&);
+diff --git a/src/editor/message_box.hpp b/src/editor/message_box.hpp
+index 385387a..d885767 100644
+--- a/src/editor/message_box.hpp
++++ b/src/editor/message_box.hpp
+@@ -45,7 +45,7 @@ public:
+   void on_cancel_button();
+ 
+ public:
+-  boost::signal<void()> on_ok;
++  boost::signals2::signal<void()> on_ok;
+ 
+ private:
+   MessageBox(const MessageBox&);
+diff --git a/src/editor/object_selector.cpp b/src/editor/object_selector.cpp
+index 28e3068..f3a36b5 100644
+--- a/src/editor/object_selector.cpp
++++ b/src/editor/object_selector.cpp
+@@ -16,7 +16,7 @@
+ 
+ #include "editor/object_selector.hpp"
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "editor/generic_level_obj.hpp"
+ #include "editor/gui_style.hpp"
+@@ -47,7 +47,7 @@ private:
+   std::string tooltip;
+   
+ public:
+-  boost::signal<void()> on_click;
++  boost::signals2::signal<void()> on_click;
+ 
+ public:
+   ObjectSelectorButton(ObjectSelectorList* object_list_,
+diff --git a/src/editor/viewport.hpp b/src/editor/viewport.hpp
+index 1ae9eff..1886825 100644
+--- a/src/editor/viewport.hpp
++++ b/src/editor/viewport.hpp
+@@ -18,7 +18,7 @@
+ #ifndef HEADER_PINGUS_EDITOR_VIEWPORT_HPP
+ #define HEADER_PINGUS_EDITOR_VIEWPORT_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ #include <set>
+ 
+ #include "editor/selection.hpp"
+@@ -148,7 +148,7 @@ public:
+ 
+   void clear_selection();
+ 
+-  boost::signal<void (const Selection&)> selection_changed;
++  boost::signals2::signal<void (const Selection&)> selection_changed;
+ private:
+   Viewport();
+   Viewport (const Viewport&);
+diff --git a/src/pingus/components/check_box.hpp b/src/pingus/components/check_box.hpp
+index 00e23b7..5bef50f 100644
+--- a/src/pingus/components/check_box.hpp
++++ b/src/pingus/components/check_box.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_PINGUS_COMPONENTS_CHECK_BOX_HPP
+ #define HEADER_PINGUS_PINGUS_COMPONENTS_CHECK_BOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/display/sprite.hpp"
+ #include "engine/gui/rect_component.hpp"
+@@ -39,7 +39,7 @@ public:
+ 
+   void set_state(bool v, bool send_signal);
+ 
+-  boost::signal<void (bool)> on_change;
++  boost::signals2::signal<void (bool)> on_change;
+ 
+ private:
+   CheckBox (const CheckBox&);
+diff --git a/src/pingus/components/choice_box.hpp b/src/pingus/components/choice_box.hpp
+index 49d6e19..ef51b6d 100644
+--- a/src/pingus/components/choice_box.hpp
++++ b/src/pingus/components/choice_box.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_PINGUS_COMPONENTS_CHOICE_BOX_HPP
+ #define HEADER_PINGUS_PINGUS_COMPONENTS_CHOICE_BOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/gui/rect_component.hpp"
+ 
+@@ -36,7 +36,7 @@ public:
+   void add_choice(const std::string& str);
+   void set_current_choice(int choice);
+   
+-  boost::signal<void (std::string)> on_change;
++  boost::signals2::signal<void (std::string)> on_change;
+   
+ private:
+   ChoiceBox (const ChoiceBox&);
+diff --git a/src/pingus/components/slider_box.hpp b/src/pingus/components/slider_box.hpp
+index ae4d924..75118ea 100644
+--- a/src/pingus/components/slider_box.hpp
++++ b/src/pingus/components/slider_box.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_PINGUS_COMPONENTS_SLIDER_BOX_HPP
+ #define HEADER_PINGUS_PINGUS_COMPONENTS_SLIDER_BOX_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "engine/gui/rect_component.hpp"
+ 
+@@ -39,7 +39,7 @@ public:
+ 
+   void set_value(int v);
+ 
+-  boost::signal<void (int)> on_change;
++  boost::signals2::signal<void (int)> on_change;
+ 
+ private:
+   SliderBox (const SliderBox&);
+diff --git a/src/pingus/config_manager.hpp b/src/pingus/config_manager.hpp
+index b07b83e..4cf08e0 100644
+--- a/src/pingus/config_manager.hpp
++++ b/src/pingus/config_manager.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_PINGUS_CONFIG_MANAGER_HPP
+ #define HEADER_PINGUS_PINGUS_CONFIG_MANAGER_HPP
+ 
+-#include <boost/signal.hpp>
++#include <boost/signals2.hpp>
+ 
+ #include "math/size.hpp"
+ #include "pingus/options.hpp"
+@@ -39,55 +39,55 @@ public:
+ 
+   void set_master_volume(int);
+   int  get_master_volume() const;
+-  boost::signal<void(int)> on_master_volume_change;
++  boost::signals2::signal<void(int)> on_master_volume_change;
+ 
+   void set_sound_volume(int);
+   int  get_sound_volume() const;
+-  boost::signal<void(int)> on_sound_volume_change;
++  boost::signals2::signal<void(int)> on_sound_volume_change;
+ 
+   void set_music_volume(int);
+   int  get_music_volume() const;
+-  boost::signal<void(int)> on_music_volume_change;
++  boost::signals2::signal<void(int)> on_music_volume_change;
+ 
+   void set_fullscreen_resolution(const Size& size);
+   Size get_fullscreen_resolution() const;
+-  boost::signal<void(Size)> on_fullscreen_resolution_change;
++  boost::signals2::signal<void(Size)> on_fullscreen_resolution_change;
+ 
+   void set_fullscreen(bool);
+   bool get_fullscreen() const;
+-  boost::signal<void(bool)> on_fullscreen_change;
++  boost::signals2::signal<void(bool)> on_fullscreen_change;
+ 
+   void set_renderer(FramebufferType type);
+   FramebufferType get_renderer() const;
+-  boost::signal<void(FramebufferType)> on_renderer_change;
++  boost::signals2::signal<void(FramebufferType)> on_renderer_change;
+ 
+   void set_resizable(bool);
+   bool get_resizable() const;
+-  boost::signal<void(bool)> on_resizable_change;
++  boost::signals2::signal<void(bool)> on_resizable_change;
+ 
+   void set_mouse_grab(bool);
+   bool get_mouse_grab() const;
+-  boost::signal<void(bool)> on_mouse_grab_change;
++  boost::signals2::signal<void(bool)> on_mouse_grab_change;
+ 
+   void set_print_fps(bool);
+   bool get_print_fps() const;
+-  boost::signal<void(bool)> on_print_fps_change;
++  boost::signals2::signal<void(bool)> on_print_fps_change;
+ 
+   void set_language(const tinygettext::Language&);
+   tinygettext::Language get_language() const;
+-  boost::signal<void(const tinygettext::Language&)> on_language_change;
++  boost::signals2::signal<void(const tinygettext::Language&)> on_language_change;
+ 
+   void set_software_cursor(bool);
+   bool get_software_cursor() const;
+-  boost::signal<void(bool)> on_software_cursor_change;
++  boost::signals2::signal<void(bool)> on_software_cursor_change;
+ 
+   void set_auto_scrolling(bool);
+   bool get_auto_scrolling() const;
+-  boost::signal<void(bool)> on_auto_scrolling_change;
++  boost::signals2::signal<void(bool)> on_auto_scrolling_change;
+ 
+   void set_drag_drop_scrolling(bool);
+   bool get_drag_drop_scrolling() const;
+-  boost::signal<void(bool)> on_drag_drop_scrolling_change;
++  boost::signals2::signal<void(bool)> on_drag_drop_scrolling_change;
+ 
+ private:
+   ConfigManager (const ConfigManager&);
+diff --git a/src/pingus/screens/option_menu.hpp b/src/pingus/screens/option_menu.hpp
+index 60b1578..154ef0f 100644
+--- a/src/pingus/screens/option_menu.hpp
++++ b/src/pingus/screens/option_menu.hpp
+@@ -17,7 +17,7 @@
+ #ifndef HEADER_PINGUS_PINGUS_SCREENS_OPTION_MENU_HPP
+ #define HEADER_PINGUS_PINGUS_SCREENS_OPTION_MENU_HPP
+ 
+-#include <boost/signals.hpp>
++#include <boost/signals2.hpp>
+ #include <map>
+ #include <vector>
+ 
+@@ -66,7 +66,7 @@ private:
+   //Label* defaults_label;
+   //CheckBox* defaults_box;
+ 
+-  typedef std::vector<boost::signals::connection> Connections;
++  typedef std::vector<boost::signals2::connection> Connections;
+   Connections connections;
+ 
+   tinygettext::Language m_language;
+-- 
+2.20.1
+

--- a/recipes-games/pingus/pingus_0.7.6.bb
+++ b/recipes-games/pingus/pingus_0.7.6.bb
@@ -11,6 +11,7 @@ inherit scons pythonnative
 SRC_URI = "\
   https://github.com/Pingus/${PN}/archive/v${PV}.tar.gz \
   file://0001-Add-missing-header-for-std-function-and-std-bind.patch \
+  file://0002-Fix-build-with-boost-1.69.0.patch \
   file://version.patch \
   file://sdl_pkgconfig.patch \
   file://pingus.desktop \

--- a/recipes-games/wesnoth/wesnoth_1.14.6.bb
+++ b/recipes-games/wesnoth/wesnoth_1.14.6.bb
@@ -13,6 +13,8 @@ SRC_URI = " \
     file://0001-Find-sdl-CFLAGS-with-pkg-config-sdl-config-is-not-us.patch \
     file://0002-Do-not-do-the-ar-ranlib-configure-dance-it-won-t-wor.patch \
 "
+SRC_URI[md5sum] = "4038b0d223dc03ebe0581a802cc41c0d"
+SRC_URI[sha256sum] = "45d2a05320e145b0b1bc9d16d68391945a98375c910a0ea7720e613bf867832b"
 
 ARM_INSTRUCTION_SET = "arm"
 
@@ -184,6 +186,3 @@ FILES_${PN}-utbs = "\
 	${datadir}/wesnoth/data/campaigns/Under_the_Burning_Suns \
 	${datadir}/wesnoth/translations/*/LC_MESSAGES/wesnoth-utbs.mo \
 "
-
-SRC_URI[md5sum] = "b6b775109569c59a7aa8d6a7537b8694"
-SRC_URI[sha256sum] = "312dcd1d5f07eb85fdbe932c0e8727e2985bce0bd521a743f7bcddded15581c3"


### PR DESCRIPTION
This fixes build with boost  1.69.0:

| <...>/wesnoth-1.14.4/src/units/frame.cpp:775:103: error: cannot convert 'boost::logic::tribool' to 'const bool' i

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>