### PR TITLE
pingus: Fix warning with latest oe-core

### DIFF
--- a/recipes-games/pingus/pingus_0.7.6.bb
+++ b/recipes-games/pingus/pingus_0.7.6.bb
@@ -9,14 +9,16 @@ RDEPENDS_${PN} += "libmikmod bash"
 inherit scons pythonnative
 
 SRC_URI = "\
-  https://github.com/Pingus/${PN}/archive/v${PV}.tar.gz \
-  file://0001-Add-missing-header-for-std-function-and-std-bind.patch \
-  file://0002-Fix-build-with-boost-1.69.0.patch \
-  file://version.patch \
-  file://sdl_pkgconfig.patch \
-  file://pingus.desktop \
-  file://pingus.png \
+    git://github.com/Pingus/pingus.git \
+    file://0001-Add-missing-header-for-std-function-and-std-bind.patch \
+    file://0002-Fix-build-with-boost-1.69.0.patch \
+    file://version.patch \
+    file://sdl_pkgconfig.patch \
+    file://pingus.desktop \
+    file://pingus.png \
 "
+SRCREV = "a147274b76509ae543db2286a8710afe2d426666"
+S = "${WORKDIR}/git"
 
 EXTRA_OESCONS = "CC='${CC} -fPIC' CXX='${CXX} -fPIC' LINKFLAGS='${LDFLAGS}'"
 CLEANBROKEN = "1"


### PR DESCRIPTION
| WARNING: pingus-0.7.6-r0 do_package_qa: QA Issue: pingus: SRC_URI uses PN not BPN [src-uri-bad]

Additionally: github rebuilds tarballs from time to time changing checksums. So
just

-  https://github.com/Pingus/${PN}/archive/v${PV}.tar.gz \
+  https://github.com/Pingus/${BPN}/archive/v${PV}.tar.gz \

would cause:
| WARNING: pingus-0.7.6-r0 do_package_qa: QA Issue:   https://github.com/Pingus/pingus/archive/v0.7.6.tar.gz   file://0001-Add-missing-header-for-std-function-and-std-bind.patch   file://0002-Fix-build-with-boost-1.69.0.patch   file://version.patch   file://sdl_pkgconfig.patch   file://pingus.desktop   file://pingus.png : SRC_URI uses unstable GitHub archives [src-uri-bad]

So get sources by downloading git repo.

While at it replace 2 spaces indention by 4 spaces.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>