### PR TITLE
astromenace/supertuxkart: Fix parse warnings

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,4 +8,4 @@ BBFILE_COLLECTIONS += "games-layer"
 BBFILE_PATTERN_games-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_games-layer = "15"
 
-LAYERSERIES_COMPAT_games-layer = "rocko sumo thud warrior zeus"
+LAYERSERIES_COMPAT_games-layer = "zeus"

--- a/recipes-games/astromenace/astromenace_1.3.2.bb
+++ b/recipes-games/astromenace/astromenace_1.3.2.bb
@@ -10,7 +10,7 @@ DEPENDS = "libsdl freealut openal-soft libogg libvorbis freetype libglu libxiner
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-inherit cmake qemu gtk-icon-cache distro_features_check
+inherit cmake qemu gtk-icon-cache features_check
 
 SRC_URI = " \
     git://github.com/viewizard/astromenace.git \

--- a/recipes-games/supertuxkart/supertuxkart_0.9.3.bb
+++ b/recipes-games/supertuxkart/supertuxkart_0.9.3.bb
@@ -18,7 +18,7 @@ DEPENDS = " \
     bluez5 \
 "
 
-inherit cmake gtk-icon-cache distro_features_check
+inherit cmake gtk-icon-cache features_check
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
oe-core deprecated distro_features_check. The new class to use is
features_check.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>