### PR TITLE
maelstrom: Fix build for 64bit targets

### DIFF
--- a/recipes-games/maelstrom/maelstrom/0005-SDL_FrameBuf.cpp-Fix-build-for-64Bit-targets.patch
+++ b/recipes-games/maelstrom/maelstrom/0005-SDL_FrameBuf.cpp-Fix-build-for-64Bit-targets.patch
@@ -1,0 +1,37 @@
+From da490238ae606cc4dcb704fb739d3e6f523b1976 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Andreas=20M=C3=BCller?= <schnitzeltony@gmail.com>
+Date: Tue, 27 Oct 2020 19:50:25 +0100
+Subject: [PATCH] SDL_FrameBuf.cpp: Fix build for 64Bit targets
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Stolen from [1]
+
+[1] https://src.fedoraproject.org/rpms/Maelstrom/blob/master/f/Maelstrom-3.0.6-64bit.patch
+
+Upstream-Status: Pending
+
+Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
+---
+ screenlib/SDL_FrameBuf.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/screenlib/SDL_FrameBuf.cpp b/screenlib/SDL_FrameBuf.cpp
+index d1e087f..430e903 100644
+--- a/screenlib/SDL_FrameBuf.cpp
++++ b/screenlib/SDL_FrameBuf.cpp
+@@ -848,8 +848,8 @@ FrameBuf:: AddDirtyRect(SDL_Rect *rect)
+ 			for ( i=0; i<dirtymaplen; ++i ) {
+ 				if ( dirtymap[i] != NULL ) {
+ 					dirtymap[i] = (SDL_Rect *)(
+-					((int)dirtymap[i]-(int)updatelist) +
+-								(int)newlist
++					((long)dirtymap[i]-(long)updatelist) +
++								(long)newlist
+ 					);
+ 				}
+ 			}
+-- 
+2.26.2
+

--- a/recipes-games/maelstrom/maelstrom_3.0.6.bb
+++ b/recipes-games/maelstrom/maelstrom_3.0.6.bb
@@ -15,6 +15,7 @@ SRC_URI = " \
     file://0002-buttonlist.h-Fix-build-with-recent-gcc-s.patch \
     file://0003-Fix-install-dir.patch \
     file://0004-Maelstrom-3.0.6-setgid.patch \
+    file://0005-SDL_FrameBuf.cpp-Fix-build-for-64Bit-targets.patch \
     file://maelstrom.png \
     file://Maelstrom.desktop \
 "


### PR DESCRIPTION
| SDL_FrameBuf.cpp:852:14: error: cast from 'SDL_Rect*' to 'int' loses precision [-fpermissive]
|   852 |         (int)newlist
|       |              ^~~~~~~

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>