### PR TITLE
wesnoth: upgrade 1.15.1 -> 1.15.12 to fix build with gcc11

### DIFF
--- a/recipes-games/wesnoth/files/0001-Find-sdl-CFLAGS-with-pkg-config-sdl-config-is-not-us.patch
+++ b/recipes-games/wesnoth/files/0001-Find-sdl-CFLAGS-with-pkg-config-sdl-config-is-not-us.patch
@@ -14,20 +14,20 @@ Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index f5c0df9..1026001 100644
+index becfff5..c1f477e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -71,8 +71,8 @@ find_package(Gettext)
- find_package(X11)
+@@ -88,8 +88,8 @@ find_package(X11)
  
  # needed to get some SDL2 defines in... (as of rev31694 -D_GNU_SOURCE=1 is required!)
--set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
--exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
-+set(SDL_CONFIG "pkg-config" CACHE STRING "Path to sdl-config script")
-+exec_program(${SDL_CONFIG} ARGS "sdl --cflags" OUTPUT_VARIABLE SDL_CFLAGS)
- add_definitions(${SDL2_CFLAGS})
- 
- if(NOT WIN32)
+ if(NOT MINGW)
+-	set(SDL2_CONFIG "sdl2-config" CACHE STRING "Path to sdl2-config script")
+-	exec_program(${SDL2_CONFIG} ARGS "--cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
++	set(SDL2_CONFIG "pkg-config" CACHE STRING "Path to sdl-config script")
++	exec_program(${SDL2_CONFIG} ARGS "sdl2 --cflags" OUTPUT_VARIABLE SDL2_CFLAGS)
+ 	add_definitions(${SDL2_CFLAGS})
+ else()
+ 	# equivalent to sdl2-config --cflags --libs
 -- 
-2.14.4
+2.30.2
 

--- a/recipes-games/wesnoth/files/0002-Do-not-do-the-ar-ranlib-configure-dance-it-won-t-wor.patch
+++ b/recipes-games/wesnoth/files/0002-Do-not-do-the-ar-ranlib-configure-dance-it-won-t-wor.patch
@@ -11,14 +11,14 @@ Upstream-Status: Inappropriate [oe specific]
 
 Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>
 ---
- CMakeLists.txt | 19 -------------------
- 1 file changed, 19 deletions(-)
+ CMakeLists.txt | 9 ---------
+ 1 file changed, 9 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1026001..15ad0bb 100644
+index c1f477e..a8c5320 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -372,25 +372,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+@@ -407,15 +407,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
  	endif(ENABLE_LTO)
  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
  
@@ -29,21 +29,11 @@ index 1026001..15ad0bb 100644
 -	find_program(LTO_RANLIB NAMES gcc-ranlib)
 -	set(CMAKE_AR "${LTO_AR}" CACHE STRING "Supports LTO" FORCE)
 -	set(CMAKE_RANLIB "${LTO_RANLIB}" CACHE STRING "Supports LTO" FORCE)
--else()
--	MESSAGE("Using ar, ranlib, and default linker")
--	find_program(NON_LTO_AR NAMES ar)
--	find_program(NON_LTO_RANLIB NAMES ranlib)
--	set(CMAKE_AR "${NON_LTO_AR}" CACHE STRING "Does not support LTO" FORCE)
--	set(CMAKE_RANLIB "${NON_LTO_RANLIB}" CACHE STRING "Does not support LTO" FORCE)
 -endif()
 -MARK_AS_ADVANCED(LTO_AR LTO_RANLIB NON_LTO_AR NON_LTO_RANLIB)
--
--# add in extra flags
--set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} ${LINK_EXTRA_FLAGS_CONFIG} ${LINK_EXTRA_FLAGS_RELEASE}")
--
- # clean the pgo data
- set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_SOURCE_DIR}/pgo_data/")
  
+ # add in extra flags
+ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} ${LINK_EXTRA_FLAGS_CONFIG} ${LINK_EXTRA_FLAGS_RELEASE}")
 -- 
-2.14.4
+2.30.2
 

--- a/recipes-games/wesnoth/wesnoth_1.15.12.bb
+++ b/recipes-games/wesnoth/wesnoth_1.15.12.bb
@@ -14,8 +14,7 @@ SRC_URI = " \
     file://0002-Do-not-do-the-ar-ranlib-configure-dance-it-won-t-wor.patch \
 "
 
-SRC_URI[md5sum] = "4d4a7ee12a97b774b6636b4856947938"
-SRC_URI[sha256sum] = "854726ec68dcb26f78f65b01a90b3bc51fd985598e59c7cc2ef72999ff2366e8"
+SRC_URI[sha256sum] = "bc591dda4b0f8ff013bb44baadfc622e81548ab6a8fa98d844908e435ccfb618"
 
 ARM_INSTRUCTION_SET = "arm"
 


### PR DESCRIPTION
* refresh patches / fix sdl patch for sdl2
* remove md5sum it is not necessary / fully supported any more

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>